### PR TITLE
44_検索条件の追加と申込み状況機能の追加

### DIFF
--- a/src/main/java/raisetech/StudentManagement/controller/StudentController.java
+++ b/src/main/java/raisetech/StudentManagement/controller/StudentController.java
@@ -17,6 +17,7 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 import raisetech.studentmanagement.domain.StudentDetail;
+import raisetech.studentmanagement.domain.StudentSearchCriteria;
 import raisetech.studentmanagement.exception.StudentNotFoundException;
 import raisetech.studentmanagement.service.StudentService;
 
@@ -70,10 +71,10 @@ public class StudentController {
     return studentDetail;
   }
 
-  @GetMapping("/search")
-  public ResponseEntity<List<StudentDetail>> searchStudentDetail() {
-    List<StudentDetail> studentDetails = service.searchStudentDetail();
-    return ResponseEntity.ok(studentDetails);
+  @PostMapping("/search")
+  public ResponseEntity<List<StudentDetail>> searchStudentDetail(@RequestBody StudentSearchCriteria criteria) {
+    List<StudentDetail> studentDetailList = service.searchStudentDetail(criteria);
+    return ResponseEntity.ok(studentDetailList);
   }
 
   /**

--- a/src/main/java/raisetech/StudentManagement/controller/StudentController.java
+++ b/src/main/java/raisetech/StudentManagement/controller/StudentController.java
@@ -85,7 +85,7 @@ public class StudentController {
       @ApiResponse(responseCode = "404", description = "受講生が見つかりません")
   })
   @GetMapping("/search")
-  public ResponseEntity<List<StudentDetail>> searchStudentDetail(@RequestBody StudentSearchCriteria criteria) {
+  public ResponseEntity<List<StudentDetail>> searchStudentDetail(StudentSearchCriteria criteria) {
     List<StudentDetail> studentDetailList = service.searchStudentDetail(criteria);
     if (studentDetailList.isEmpty())
       throw new StudentDetailNotFoundException("該当する受講生が見つかりませんでした。");

--- a/src/main/java/raisetech/StudentManagement/controller/StudentController.java
+++ b/src/main/java/raisetech/StudentManagement/controller/StudentController.java
@@ -18,6 +18,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 import raisetech.studentmanagement.domain.StudentDetail;
 import raisetech.studentmanagement.domain.StudentSearchCriteria;
+import raisetech.studentmanagement.exception.StudentDetailNotFoundException;
 import raisetech.studentmanagement.exception.StudentNotFoundException;
 import raisetech.studentmanagement.service.StudentService;
 
@@ -74,6 +75,8 @@ public class StudentController {
   @PostMapping("/search")
   public ResponseEntity<List<StudentDetail>> searchStudentDetail(@RequestBody StudentSearchCriteria criteria) {
     List<StudentDetail> studentDetailList = service.searchStudentDetail(criteria);
+    if (studentDetailList.isEmpty())
+      throw new StudentDetailNotFoundException("該当する受講生が見つかりませんでした。");
     return ResponseEntity.ok(studentDetailList);
   }
 

--- a/src/main/java/raisetech/StudentManagement/controller/StudentController.java
+++ b/src/main/java/raisetech/StudentManagement/controller/StudentController.java
@@ -72,6 +72,13 @@ public class StudentController {
     return studentDetail;
   }
 
+  /**
+   * 条件を指定した受講生詳細の検索
+   * 検索条件はJson形式で渡す
+   *
+   * @param criteria 検索条件
+   * @return 受講生詳細リスト
+   */
   @PostMapping("/search")
   public ResponseEntity<List<StudentDetail>> searchStudentDetail(@RequestBody StudentSearchCriteria criteria) {
     List<StudentDetail> studentDetailList = service.searchStudentDetail(criteria);

--- a/src/main/java/raisetech/StudentManagement/controller/StudentController.java
+++ b/src/main/java/raisetech/StudentManagement/controller/StudentController.java
@@ -79,6 +79,11 @@ public class StudentController {
    * @param criteria 検索条件
    * @return 受講生詳細リスト
    */
+  @Operation(summary = "受講生詳細絞り込み検索", description = "指定した条件で受講生詳細を検索します。")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "成功"),
+      @ApiResponse(responseCode = "404", description = "受講生が見つかりません")
+  })
   @PostMapping("/search")
   public ResponseEntity<List<StudentDetail>> searchStudentDetail(@RequestBody StudentSearchCriteria criteria) {
     List<StudentDetail> studentDetailList = service.searchStudentDetail(criteria);

--- a/src/main/java/raisetech/StudentManagement/controller/StudentController.java
+++ b/src/main/java/raisetech/StudentManagement/controller/StudentController.java
@@ -70,6 +70,12 @@ public class StudentController {
     return studentDetail;
   }
 
+  @GetMapping("/search")
+  public ResponseEntity<List<StudentDetail>> searchStudentDetail() {
+    List<StudentDetail> studentDetails = service.searchStudentDetail();
+    return ResponseEntity.ok(studentDetails);
+  }
+
   /**
    * 新規受講生の登録
    * コース情報と申し込み状況も一緒に登録する

--- a/src/main/java/raisetech/StudentManagement/controller/StudentController.java
+++ b/src/main/java/raisetech/StudentManagement/controller/StudentController.java
@@ -84,7 +84,7 @@ public class StudentController {
       @ApiResponse(responseCode = "200", description = "成功"),
       @ApiResponse(responseCode = "404", description = "受講生が見つかりません")
   })
-  @PostMapping("/search")
+  @GetMapping("/search")
   public ResponseEntity<List<StudentDetail>> searchStudentDetail(@RequestBody StudentSearchCriteria criteria) {
     List<StudentDetail> studentDetailList = service.searchStudentDetail(criteria);
     if (studentDetailList.isEmpty())

--- a/src/main/java/raisetech/StudentManagement/controller/converter/StudentConverter.java
+++ b/src/main/java/raisetech/StudentManagement/controller/converter/StudentConverter.java
@@ -45,6 +45,12 @@ public class StudentConverter {
     return studentDetailList;
   }
 
+  /**
+   *　重複して取得された受講生情報を一つの受講生詳細にまとめる
+   *
+   * @param studentDetailList 受講生詳細リスト(生データ)
+   * @return 重複をまとめた受講生詳細リスト
+   */
   public List<StudentDetail> convertSearchedStudentDetailList(List<StudentDetail> studentDetailList) {
     Map<Integer, StudentDetail> studentDetailMap = new HashMap<>();
 

--- a/src/main/java/raisetech/StudentManagement/controller/converter/StudentConverter.java
+++ b/src/main/java/raisetech/StudentManagement/controller/converter/StudentConverter.java
@@ -45,6 +45,21 @@ public class StudentConverter {
     return studentDetailList;
   }
 
+  public List<StudentDetail> convertSearchedStudentDetailList(List<StudentDetail> studentDetailList) {
+    Map<Integer, StudentDetail> studentDetailMap = new HashMap<>();
+
+    studentDetailList.forEach(studentDetail -> {
+      int studentId = studentDetail.getStudent().getId();
+      if (studentDetailMap.containsKey(studentId)) {
+        studentDetailMap.get(studentId).getStudentCourseDetailList()
+            .addAll(studentDetail.getStudentCourseDetailList());
+      } else {
+        studentDetailMap.put(studentId, studentDetail);
+      }
+    });
+    return new ArrayList<>(studentDetailMap.values());
+  }
+
   /**
    * 申し込み状況リストをコースIDをキーとするマップに変換
    * コースIDによる申し込み状況の検索を高速化するため

--- a/src/main/java/raisetech/StudentManagement/domain/StudentCourseDetail.java
+++ b/src/main/java/raisetech/StudentManagement/domain/StudentCourseDetail.java
@@ -1,6 +1,7 @@
 package raisetech.studentmanagement.domain;
 
 import jakarta.validation.Valid;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -10,6 +11,7 @@ import raisetech.studentmanagement.data.StudentCourse;
 @Getter
 @Setter
 @NoArgsConstructor
+@AllArgsConstructor
 public class StudentCourseDetail {
 
   @Valid

--- a/src/main/java/raisetech/StudentManagement/domain/StudentSearchCriteria.java
+++ b/src/main/java/raisetech/StudentManagement/domain/StudentSearchCriteria.java
@@ -1,0 +1,22 @@
+package raisetech.studentmanagement.domain;
+
+import java.time.LocalDate;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class StudentSearchCriteria {
+  private String fullName;
+  private String furigana;
+  private String nickname;
+  private String emailAddress;
+  private String area;
+  private Integer age;
+  private String gender;
+  private String remark;
+  private String courseName;
+  private LocalDate startDate;
+  private LocalDate endDate;
+  private String status;
+}

--- a/src/main/java/raisetech/StudentManagement/domain/StudentSearchCriteria.java
+++ b/src/main/java/raisetech/StudentManagement/domain/StudentSearchCriteria.java
@@ -1,6 +1,6 @@
 package raisetech.studentmanagement.domain;
 
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -16,7 +16,7 @@ public class StudentSearchCriteria {
   private String gender;
   private String remark;
   private String courseName;
-  private LocalDate startDate;
-  private LocalDate endDate;
+  private LocalDateTime startDate;
+  private LocalDateTime endDate;
   private String status;
 }

--- a/src/main/java/raisetech/StudentManagement/exception/StudentDetailNotFoundException.java
+++ b/src/main/java/raisetech/StudentManagement/exception/StudentDetailNotFoundException.java
@@ -1,7 +1,7 @@
 package raisetech.studentmanagement.exception;
 
 /**
- * ControllerのgetStudentメソッドで存在しないIDがリクエストされた際の例外クラス
+ * 条件を指定した受講生の検索で該当する受講生が見つからなかった際の例外クラス
  */
 public class StudentDetailNotFoundException extends RuntimeException{
 

--- a/src/main/java/raisetech/StudentManagement/exception/StudentDetailNotFoundException.java
+++ b/src/main/java/raisetech/StudentManagement/exception/StudentDetailNotFoundException.java
@@ -1,0 +1,11 @@
+package raisetech.studentmanagement.exception;
+
+/**
+ * ControllerのgetStudentメソッドで存在しないIDがリクエストされた際の例外クラス
+ */
+public class StudentDetailNotFoundException extends RuntimeException{
+
+  public StudentDetailNotFoundException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/raisetech/StudentManagement/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/raisetech/StudentManagement/exception/handler/GlobalExceptionHandler.java
@@ -16,6 +16,7 @@ public class GlobalExceptionHandler {
 
   /**
    * ControllerのgetStudentメソッドで存在しないIDがリクエストされた際の例外をハンドリングする
+   *
    * @param ex StudentNotFoundException
    * @return "error": "受講生ID: idが見つかりません。"
    */
@@ -26,6 +27,12 @@ public class GlobalExceptionHandler {
     return new ResponseEntity<>(errorResponse, HttpStatus.NOT_FOUND);
   }
 
+  /**
+   * ControllerのsearchStudentDetailメソッドで検索条件に一致する受講生が見つからなかった際の例外をハンドリングする
+   *
+   * @param ex StudentDetailNotFoundException
+   * @return "error": "該当する受講生が見つかりませんでした。"
+   */
   @ExceptionHandler(StudentDetailNotFoundException.class)
   public ResponseEntity<Map<String, String>> handleStudentDetailNotFoundException(StudentDetailNotFoundException ex) {
     Map<String, String> errorResponse = new HashMap<>();
@@ -35,6 +42,7 @@ public class GlobalExceptionHandler {
 
   /**
    * Post,Put処理の入力チェックでBAD_REQUESTが発生した際の例外をハンドリングする
+   *
    * @param ex handleMethodArgumentNotValidException
    * @return カラム名とデフォルトのエラーメッセージ
    */

--- a/src/main/java/raisetech/StudentManagement/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/raisetech/StudentManagement/exception/handler/GlobalExceptionHandler.java
@@ -8,6 +8,7 @@ import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import raisetech.studentmanagement.exception.StudentDetailNotFoundException;
 import raisetech.studentmanagement.exception.StudentNotFoundException;
 
 @ControllerAdvice
@@ -20,6 +21,13 @@ public class GlobalExceptionHandler {
    */
   @ExceptionHandler(StudentNotFoundException.class)
   public ResponseEntity<Map<String, String>> handleStudentNotFoundException(StudentNotFoundException ex) {
+    Map<String, String> errorResponse = new HashMap<>();
+    errorResponse.put("error", ex.getMessage());
+    return new ResponseEntity<>(errorResponse, HttpStatus.NOT_FOUND);
+  }
+
+  @ExceptionHandler(StudentDetailNotFoundException.class)
+  public ResponseEntity<Map<String, String>> handleStudentDetailNotFoundException(StudentDetailNotFoundException ex) {
     Map<String, String> errorResponse = new HashMap<>();
     errorResponse.put("error", ex.getMessage());
     return new ResponseEntity<>(errorResponse, HttpStatus.NOT_FOUND);

--- a/src/main/java/raisetech/StudentManagement/repository/StudentRepository.java
+++ b/src/main/java/raisetech/StudentManagement/repository/StudentRepository.java
@@ -5,6 +5,7 @@ import org.apache.ibatis.annotations.Mapper;
 import raisetech.studentmanagement.data.CourseApplicationStatus;
 import raisetech.studentmanagement.data.Student;
 import raisetech.studentmanagement.data.StudentCourse;
+import raisetech.studentmanagement.domain.StudentDetail;
 
 /**
  * 受講生テーブルとコース情報テーブルと紐づくリポジトリ
@@ -105,4 +106,6 @@ public interface StudentRepository {
    * @param courseApplicationStatus 申し込み状況
    */
   void updateCourseApplicationStatus(CourseApplicationStatus courseApplicationStatus);
+
+  List<StudentDetail> searchStudentDetail();
 }

--- a/src/main/java/raisetech/StudentManagement/repository/StudentRepository.java
+++ b/src/main/java/raisetech/StudentManagement/repository/StudentRepository.java
@@ -59,6 +59,13 @@ public interface StudentRepository {
    */
   CourseApplicationStatus findCourseApplicationStatusByCourseId(int courseId);
 
+  /**
+   * 条件を指定した受講生詳細の検索
+   * 検索条件が指定されていないときは全件を返す
+   *
+   * @param criteria 検索条件
+   * @return 受講生詳細リスト
+   */
   List<StudentDetail> searchStudentDetail(StudentSearchCriteria criteria);
 
   /**

--- a/src/main/java/raisetech/StudentManagement/repository/StudentRepository.java
+++ b/src/main/java/raisetech/StudentManagement/repository/StudentRepository.java
@@ -6,6 +6,7 @@ import raisetech.studentmanagement.data.CourseApplicationStatus;
 import raisetech.studentmanagement.data.Student;
 import raisetech.studentmanagement.data.StudentCourse;
 import raisetech.studentmanagement.domain.StudentDetail;
+import raisetech.studentmanagement.domain.StudentSearchCriteria;
 
 /**
  * 受講生テーブルとコース情報テーブルと紐づくリポジトリ
@@ -58,6 +59,8 @@ public interface StudentRepository {
    */
   CourseApplicationStatus findCourseApplicationStatusByCourseId(int courseId);
 
+  List<StudentDetail> searchStudentDetail(StudentSearchCriteria criteria);
+
   /**
    * 新規受講生情報の登録
    * IDは自動採番
@@ -106,6 +109,4 @@ public interface StudentRepository {
    * @param courseApplicationStatus 申し込み状況
    */
   void updateCourseApplicationStatus(CourseApplicationStatus courseApplicationStatus);
-
-  List<StudentDetail> searchStudentDetail();
 }

--- a/src/main/java/raisetech/StudentManagement/repository/StudentRepository.java
+++ b/src/main/java/raisetech/StudentManagement/repository/StudentRepository.java
@@ -62,6 +62,8 @@ public interface StudentRepository {
   /**
    * 条件を指定した受講生詳細の検索
    * 検索条件が指定されていないときは全件を返す
+   * 生データなので、複数コースが登録されている場合、受講生情報が重複して取得される
+   * 重複したデータをまとめる処理はService(Converter)で行う
    *
    * @param criteria 検索条件
    * @return 受講生詳細リスト

--- a/src/main/java/raisetech/StudentManagement/service/StudentService.java
+++ b/src/main/java/raisetech/StudentManagement/service/StudentService.java
@@ -70,6 +70,10 @@ public class StudentService {
     return new StudentDetail(student, studentCourseDetailList);
   }
 
+  public List<StudentDetail> searchStudentDetail() {
+    return repository.searchStudentDetail();
+  }
+
   /**
    * 新規受講生の登録
    * コース情報と申し込み状況も一緒に登録する

--- a/src/main/java/raisetech/StudentManagement/service/StudentService.java
+++ b/src/main/java/raisetech/StudentManagement/service/StudentService.java
@@ -12,6 +12,7 @@ import raisetech.studentmanagement.data.Student;
 import raisetech.studentmanagement.data.StudentCourse;
 import raisetech.studentmanagement.domain.StudentCourseDetail;
 import raisetech.studentmanagement.domain.StudentDetail;
+import raisetech.studentmanagement.domain.StudentSearchCriteria;
 import raisetech.studentmanagement.repository.StudentRepository;
 
 /**
@@ -70,8 +71,8 @@ public class StudentService {
     return new StudentDetail(student, studentCourseDetailList);
   }
 
-  public List<StudentDetail> searchStudentDetail() {
-    return repository.searchStudentDetail();
+  public List<StudentDetail> searchStudentDetail(StudentSearchCriteria criteria) {
+    return repository.searchStudentDetail(criteria);
   }
 
   /**

--- a/src/main/java/raisetech/StudentManagement/service/StudentService.java
+++ b/src/main/java/raisetech/StudentManagement/service/StudentService.java
@@ -71,6 +71,14 @@ public class StudentService {
     return new StudentDetail(student, studentCourseDetailList);
   }
 
+  /**
+   * 条件を指定した受講生詳細の検索
+   * リポジトリから取得した生データを
+   * コンバータで重複をまとめた受講生詳細リストに変換する
+   *
+   * @param criteria リスト
+   * @return 重複をまとめた受講生詳細リスト
+   */
   public List<StudentDetail> searchStudentDetail(StudentSearchCriteria criteria) {
     List<StudentDetail> studentDetailList = repository.searchStudentDetail(criteria);
     return converter.convertSearchedStudentDetailList(studentDetailList);

--- a/src/main/java/raisetech/StudentManagement/service/StudentService.java
+++ b/src/main/java/raisetech/StudentManagement/service/StudentService.java
@@ -72,7 +72,8 @@ public class StudentService {
   }
 
   public List<StudentDetail> searchStudentDetail(StudentSearchCriteria criteria) {
-    return repository.searchStudentDetail(criteria);
+    List<StudentDetail> studentDetailList = repository.searchStudentDetail(criteria);
+    return converter.convertSearchedStudentDetailList(studentDetailList);
   }
 
   /**

--- a/src/main/resources/mapper/studentRepository.xml
+++ b/src/main/resources/mapper/studentRepository.xml
@@ -188,5 +188,4 @@
       </association>
     </collection>
   </resultMap>
-
 </mapper>

--- a/src/main/resources/mapper/studentRepository.xml
+++ b/src/main/resources/mapper/studentRepository.xml
@@ -33,6 +33,37 @@
     SELECT * FROM course_application_statuses WHERE course_id = #{courseId}
   </select>
 
+  <!-- 条件を指定して受講生詳細を検索　-->
+  <select id="searchStudentDetail" resultMap="StudentDetailResultMap">
+    SELECT
+    s.id AS student_id,
+    s.full_name,
+    s.furigana,
+    s.nickname,
+    s.email_address,
+    s.area,
+    s.age,
+    s.gender,
+    s.remark,
+    s.is_deleted,
+    sc.id AS student_course_id,
+    sc.student_id,
+    sc.course_name,
+    sc.start_date,
+    sc.end_date,
+    cas.id AS course_application_status_id,
+    cas.course_id,
+    cas.status
+    FROM
+    students s
+    LEFT JOIN
+    students_courses sc ON s.id = sc.student_id
+    LEFT JOIN
+    course_application_statuses cas ON sc.id = cas.course_id
+    WHERE
+    s.is_deleted IS false;
+  </select>
+
   <!-- 新規受講生情報の登録 -->
   <insert id="insertStudent" useGeneratedKeys="true" keyProperty="id">
     INSERT INTO students (full_name, furigana, nickname, email_address, area, age, gender, remark, is_deleted)
@@ -85,4 +116,41 @@
     SET status = #{status}
     WHERE course_id = #{courseId}
   </update>
+
+  <!-- StudentDetail のマッピング -->
+  <resultMap id="StudentDetailResultMap" type="raisetech.studentmanagement.domain.StudentDetail">
+    <!-- Student のマッピング -->
+    <association property="student" javaType="raisetech.studentmanagement.data.Student">
+      <id column="student_id" property="id"/>
+      <result column="full_name" property="fullName"/>
+      <result column="furigana" property="furigana"/>
+      <result column="nickname" property="nickname"/>
+      <result column="email_address" property="emailAddress"/>
+      <result column="area" property="area"/>
+      <result column="age" property="age"/>
+      <result column="gender" property="gender"/>
+      <result column="remark" property="remark"/>
+      <result column="is_deleted" property="isDeleted"/>
+    </association>
+
+    <!-- StudentCourseDetail のマッピング -->
+    <collection property="studentCourseDetailList" ofType="raisetech.studentmanagement.domain.StudentCourseDetail">
+      <!-- StudentCourse のマッピング -->
+      <association property="studentCourse" javaType="raisetech.studentmanagement.data.StudentCourse">
+        <id column="student_course_id" property="id"/>
+        <result column="student_id" property="studentId"/>
+        <result column="course_name" property="courseName"/>
+        <result column="start_date" property="startDate"/>
+        <result column="end_date" property="endDate"/>
+      </association>
+
+      <!-- CourseApplicationStatus のマッピング -->
+      <association property="courseApplicationStatus" javaType="raisetech.studentmanagement.data.CourseApplicationStatus">
+        <id column="course_application_status_id" property="id"/>
+        <result column="course_id" property="courseId"/>
+        <result column="status" property="status"/>
+      </association>
+    </collection>
+  </resultMap>
+
 </mapper>

--- a/src/main/resources/mapper/studentRepository.xml
+++ b/src/main/resources/mapper/studentRepository.xml
@@ -89,11 +89,11 @@
     <if test="courseName != null and courseName != ''">
       AND sc.course_name LIKE CONCAT('%', #{courseName}, '%')
     </if>
-    <if test="startDate != null and startDate != ''">
-      AND sc.start_date >= #{startDate}
+    <if test="startDate != null">
+      AND start_date &gt;= #{startDate, jdbcType=TIMESTAMP}
     </if>
-    <if test="endDate != null and endDate != ''">
-      AND sc.end_date &lt;= #{endDate}
+    <if test="endDate != null">
+      AND end_date &lt;= #{endDate, jdbcType=TIMESTAMP}
     </if>
     <if test="status != null and status != ''">
       AND cas.status LIKE CONCAT('%', #{status}, '%')

--- a/src/main/resources/mapper/studentRepository.xml
+++ b/src/main/resources/mapper/studentRepository.xml
@@ -36,68 +36,68 @@
   <!-- 条件を指定して受講生詳細を検索 -->
   <select id="searchStudentDetail" resultMap="StudentDetailResultMap">
     SELECT
-    s.id AS student_id,
-    s.full_name,
-    s.furigana,
-    s.nickname,
-    s.email_address,
-    s.area,
-    s.age,
-    s.gender,
-    s.remark,
-    s.is_deleted,
-    sc.id AS student_course_id,
-    sc.student_id,
-    sc.course_name,
-    sc.start_date,
-    sc.end_date,
-    cas.id AS course_application_status_id,
-    cas.course_id,
-    cas.status
+      s.id AS student_id,
+      s.full_name,
+      s.furigana,
+      s.nickname,
+      s.email_address,
+      s.area,
+      s.age,
+      s.gender,
+      s.remark,
+      s.is_deleted,
+      sc.id AS student_course_id,
+      sc.student_id,
+      sc.course_name,
+      sc.start_date,
+      sc.end_date,
+      cas.id AS course_application_status_id,
+      cas.course_id,
+      cas.status
     FROM
-    students s
-    LEFT JOIN
-    students_courses sc ON s.id = sc.student_id
-    LEFT JOIN
-    course_application_statuses cas ON sc.id = cas.course_id
+      students s
+    INNER JOIN
+      students_courses sc ON s.id = sc.student_id
+    INNER JOIN
+      course_application_statuses cas ON sc.id = cas.course_id
     WHERE
-    s.is_deleted IS false
-    <if test="fullName != null and fullName != ''">
-      AND s.full_name LIKE CONCAT('%', #{fullName}, '%')
-    </if>
-    <if test="furigana != null and furigana != ''">
-      AND s.furigana LIKE CONCAT('%', #{furigana}, '%')
-    </if>
-    <if test="nickname != null and nickname != ''">
-      AND s.nickname LIKE CONCAT('%', #{nickname}, '%')
-    </if>
-    <if test="emailAddress != null and emailAddress != ''">
-      AND s.email_address LIKE CONCAT('%', #{emailAddress}, '%')
-    </if>
-    <if test="area != null and area != ''">
-      AND s.area LIKE CONCAT('%', #{area}, '%')
-    </if>
-    <if test="age != null">
-      AND s.age = #{age}
-    </if>
-    <if test="gender != null and gender != ''">
-      AND s.gender = #{gender}
-    </if>
-    <if test="remark != null and remark != ''">
-      AND s.remark LIKE CONCAT('%', #{remark}, '%')
-    </if>
-    <if test="courseName != null and courseName != ''">
-      AND sc.course_name LIKE CONCAT('%', #{courseName}, '%')
-    </if>
-    <if test="startDate != null">
-      AND start_date &gt;= #{startDate, jdbcType=TIMESTAMP}
-    </if>
-    <if test="endDate != null">
-      AND end_date &lt;= #{endDate, jdbcType=TIMESTAMP}
-    </if>
-    <if test="status != null and status != ''">
-      AND cas.status LIKE CONCAT('%', #{status}, '%')
-    </if>
+      s.is_deleted IS false
+      <if test="fullName != null and fullName != ''">
+        AND s.full_name LIKE CONCAT('%', #{fullName}, '%')
+      </if>
+      <if test="furigana != null and furigana != ''">
+        AND s.furigana LIKE CONCAT('%', #{furigana}, '%')
+      </if>
+      <if test="nickname != null and nickname != ''">
+        AND s.nickname LIKE CONCAT('%', #{nickname}, '%')
+      </if>
+      <if test="emailAddress != null and emailAddress != ''">
+        AND s.email_address LIKE CONCAT('%', #{emailAddress}, '%')
+      </if>
+      <if test="area != null and area != ''">
+        AND s.area LIKE CONCAT('%', #{area}, '%')
+      </if>
+      <if test="age != null">
+        AND s.age = #{age}
+      </if>
+      <if test="gender != null and gender != ''">
+        AND s.gender = #{gender}
+      </if>
+      <if test="remark != null and remark != ''">
+        AND s.remark LIKE CONCAT('%', #{remark}, '%')
+      </if>
+      <if test="courseName != null and courseName != ''">
+        AND sc.course_name LIKE CONCAT('%', #{courseName}, '%')
+      </if>
+      <if test="startDate != null">
+        AND start_date &gt;= #{startDate, jdbcType=TIMESTAMP}
+      </if>
+      <if test="endDate != null">
+        AND end_date &lt;= #{endDate, jdbcType=TIMESTAMP}
+      </if>
+      <if test="status != null and status != ''">
+        AND cas.status LIKE CONCAT('%', #{status}, '%')
+      </if>
   </select>
 
   <!-- 新規受講生情報の登録 -->

--- a/src/main/resources/mapper/studentRepository.xml
+++ b/src/main/resources/mapper/studentRepository.xml
@@ -33,7 +33,7 @@
     SELECT * FROM course_application_statuses WHERE course_id = #{courseId}
   </select>
 
-  <!-- 条件を指定して受講生詳細を検索　-->
+  <!-- 条件を指定して受講生詳細を検索 -->
   <select id="searchStudentDetail" resultMap="StudentDetailResultMap">
     SELECT
     s.id AS student_id,
@@ -61,7 +61,43 @@
     LEFT JOIN
     course_application_statuses cas ON sc.id = cas.course_id
     WHERE
-    s.is_deleted IS false;
+    s.is_deleted IS false
+    <if test="fullName != null and fullName != ''">
+      AND s.full_name LIKE CONCAT('%', #{fullName}, '%')
+    </if>
+    <if test="furigana != null and furigana != ''">
+      AND s.furigana LIKE CONCAT('%', #{furigana}, '%')
+    </if>
+    <if test="nickname != null and nickname != ''">
+      AND s.nickname LIKE CONCAT('%', #{nickname}, '%')
+    </if>
+    <if test="emailAddress != null and emailAddress != ''">
+      AND s.email_address LIKE CONCAT('%', #{emailAddress}, '%')
+    </if>
+    <if test="area != null and area != ''">
+      AND s.area LIKE CONCAT('%', #{area}, '%')
+    </if>
+    <if test="age != null">
+      AND s.age = #{age}
+    </if>
+    <if test="gender != null and gender != ''">
+      AND s.gender = #{gender}
+    </if>
+    <if test="remark != null and remark != ''">
+      AND s.remark LIKE CONCAT('%', #{remark}, '%')
+    </if>
+    <if test="courseName != null and courseName != ''">
+      AND sc.course_name LIKE CONCAT('%', #{courseName}, '%')
+    </if>
+    <if test="startDate != null and startDate != ''">
+      AND sc.start_date >= #{startDate}
+    </if>
+    <if test="endDate != null and endDate != ''">
+      AND sc.end_date &lt;= #{endDate}
+    </if>
+    <if test="status != null and status != ''">
+      AND cas.status LIKE CONCAT('%', #{status}, '%')
+    </if>
   </select>
 
   <!-- 新規受講生情報の登録 -->

--- a/src/test/java/raisetech/StudentManagement/controller/StudentControllerTest.java
+++ b/src/test/java/raisetech/StudentManagement/controller/StudentControllerTest.java
@@ -25,7 +25,6 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import raisetech.studentmanagement.data.Student;
 import raisetech.studentmanagement.domain.StudentCourseDetail;
 import raisetech.studentmanagement.domain.StudentDetail;
-import raisetech.studentmanagement.domain.StudentSearchCriteria;
 import raisetech.studentmanagement.service.StudentService;
 
 @WebMvcTest(StudentController.class)
@@ -50,8 +49,8 @@ class StudentControllerTest {
    * コース詳細情報は空
    */
   private StudentDetail createValidStudentDetail() {
-    Student student = new Student(id, "氏名", "フリガナ", "ニックネーム", "test@example.com",
-        "地域", 99, "性別", "備考", false);
+    Student student = new Student(id, "三宅崚介", "ミヤケリョウスケ", "Leng", "miyake@example.com",
+        "神奈川", 26, "男性", "備考", false);
     List<StudentCourseDetail> studentCourseDetailList = new ArrayList<>();
     return new StudentDetail(student, studentCourseDetailList);
   }
@@ -88,16 +87,14 @@ class StudentControllerTest {
 
   @Test
   void 条件に合致する受講生詳細が正常に返されること() throws Exception {
-    StudentSearchCriteria criteria = new StudentSearchCriteria();
-
     List<StudentDetail> studentDetailList = new ArrayList<>();
     studentDetailList.add(createValidStudentDetail());
 
     when(service.searchStudentDetail(any())).thenReturn(studentDetailList);
 
-    mockMvc.perform(MockMvcRequestBuilders.post("/search")
-        .contentType(MediaType.APPLICATION_JSON)
-        .content(objectMapper.writeValueAsString(criteria)))
+    mockMvc.perform(MockMvcRequestBuilders.get("/search")
+            .param("fullName", "三宅崚介")
+            .contentType(MediaType.APPLICATION_JSON))
         .andExpect(status().isOk());
 
     verify(service, times(1)).searchStudentDetail(any());
@@ -105,13 +102,11 @@ class StudentControllerTest {
 
   @Test
   void 検索条件に合致する受講生が見つからない場合に404エラーが返されること() throws Exception {
-    StudentSearchCriteria criteria = new StudentSearchCriteria();
-
     when(service.searchStudentDetail(any())).thenReturn(new ArrayList<>());
 
-    mockMvc.perform(MockMvcRequestBuilders.post("/search")
-            .contentType(MediaType.APPLICATION_JSON)
-            .content(objectMapper.writeValueAsString(criteria)))
+    mockMvc.perform(MockMvcRequestBuilders.get("/search")
+            .param("fullName", "名無し")
+            .contentType(MediaType.APPLICATION_JSON))
         .andExpect(status().isNotFound());
 
     verify(service, times(1)).searchStudentDetail(any());

--- a/src/test/java/raisetech/StudentManagement/controller/StudentControllerTest.java
+++ b/src/test/java/raisetech/StudentManagement/controller/StudentControllerTest.java
@@ -25,6 +25,7 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import raisetech.studentmanagement.data.Student;
 import raisetech.studentmanagement.domain.StudentCourseDetail;
 import raisetech.studentmanagement.domain.StudentDetail;
+import raisetech.studentmanagement.domain.StudentSearchCriteria;
 import raisetech.studentmanagement.service.StudentService;
 
 @WebMvcTest(StudentController.class)
@@ -83,6 +84,37 @@ class StudentControllerTest {
         .andExpect(status().isNotFound());
 
     verify(service, times(1)).searchStudent(id);
+  }
+
+  @Test
+  void 条件に合致する受講生詳細が正常に返されること() throws Exception {
+    StudentSearchCriteria criteria = new StudentSearchCriteria();
+
+    List<StudentDetail> studentDetailList = new ArrayList<>();
+    studentDetailList.add(createValidStudentDetail());
+
+    when(service.searchStudentDetail(any())).thenReturn(studentDetailList);
+
+    mockMvc.perform(MockMvcRequestBuilders.post("/search")
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(objectMapper.writeValueAsString(criteria)))
+        .andExpect(status().isOk());
+
+    verify(service, times(1)).searchStudentDetail(any());
+  }
+
+  @Test
+  void 検索条件に合致する受講生が見つからない場合に404エラーが返されること() throws Exception {
+    StudentSearchCriteria criteria = new StudentSearchCriteria();
+
+    when(service.searchStudentDetail(any())).thenReturn(new ArrayList<>());
+
+    mockMvc.perform(MockMvcRequestBuilders.post("/search")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(criteria)))
+        .andExpect(status().isNotFound());
+
+    verify(service, times(1)).searchStudentDetail(any());
   }
 
   @Test

--- a/src/test/java/raisetech/StudentManagement/controller/converter/StudentConverterTest.java
+++ b/src/test/java/raisetech/StudentManagement/controller/converter/StudentConverterTest.java
@@ -4,6 +4,7 @@ package raisetech.studentmanagement.controller.converter;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
@@ -54,19 +55,84 @@ class StudentConverterTest {
     List<StudentDetail> actual = sut.convertStudentDetailList(studentList, studentCourseList,
         courseApplicationStatusList);
 
+    // 検証
+    assertStudentDetailList(actual, student1, course1, course2, status1, status2, student2, course3, status3);
+  }
+
+  @Test
+  void 重複して取得された受講生情報を一つの受講生詳細にまとめられること() {
+    // テスト用の受講生情報
+    Student student1 = new Student(1, "氏名", "フリガナ", "ニックネーム", "test@sample.com", "地域",
+        99, "性別", "備考", false);
+    Student student2 = new Student(2, "氏名", "フリガナ", "ニックネーム", "test@sample.com", "地域",
+        99, "性別", "備考", false);
+
+    // テスト用のコース情報
+    StudentCourse course1 = new StudentCourse(1, 1, "コース名", LocalDateTime.now(),
+        LocalDateTime.now().plusYears(1));
+    StudentCourse course2 = new StudentCourse(2, 1, "コース名", LocalDateTime.now(),
+        LocalDateTime.now().plusYears(1));
+    StudentCourse course3 = new StudentCourse(3, 2, "コース名", LocalDateTime.now(),
+        LocalDateTime.now().plusYears(1));
+
+    // テスト用の申し込み状況
+    CourseApplicationStatus status1 = new CourseApplicationStatus(1, 1, "仮申込");
+    CourseApplicationStatus status2 = new CourseApplicationStatus(2, 2, "本申込");
+    CourseApplicationStatus status3 = new CourseApplicationStatus(3, 3, "受講中");
+
+    // StudentCourseDetailを作成
+    StudentCourseDetail courseDetail1 = new StudentCourseDetail(course1, status1);
+    StudentCourseDetail courseDetail2 = new StudentCourseDetail(course2, status2);
+    StudentCourseDetail courseDetail3 = new StudentCourseDetail(course3, status3);
+
+    // StudentCourseDetailをリスト化
+    List<StudentCourseDetail> courseDetailList1 = new ArrayList<>();
+    courseDetailList1.add(courseDetail1);
+    List<StudentCourseDetail> courseDetailList2 = new ArrayList<>();
+    courseDetailList2.add(courseDetail2);
+    List<StudentCourseDetail> courseDetailList3 = new ArrayList<>();
+    courseDetailList3.add(courseDetail3);
+
+    // StudentDetailを作成
+    StudentDetail detail1 = new StudentDetail(student1, courseDetailList1);
+    StudentDetail detail2 = new StudentDetail(student1, courseDetailList2);
+    StudentDetail detail3 = new StudentDetail(student2, courseDetailList3);
+
+    // StudentDetailをリスト化
+    List<StudentDetail> studentDetailList = new ArrayList<>();
+    studentDetailList.add(detail1);
+    studentDetailList.add(detail2);
+    studentDetailList.add(detail3);
+
+    // 変換処理を実行
+    List<StudentDetail> actual = sut.convertSearchedStudentDetailList(studentDetailList);
+
+    // 検証
+    assertStudentDetailList(actual, student1, course1, course2, status1, status2, student2, course3,
+        status3);
+  }
+
+  // 共通の検証メソッド
+  private void assertStudentDetailList(List<StudentDetail> actual, Student student1, StudentCourse course1,
+      StudentCourse course2, CourseApplicationStatus status1, CourseApplicationStatus status2,
+      Student student2, StudentCourse course3, CourseApplicationStatus status3) {
     // 受講生詳細リストのサイズを検証
     assertThat(actual.size()).isEqualTo(2);
 
     // 1人目の受講生詳細の中身を検証
     assertThat(actual.getFirst().getStudent()).isEqualTo(student1);
     List<StudentCourseDetail> studentCourseDetailList1 = actual.getFirst().getStudentCourseDetailList();
-    assertThat(studentCourseDetailList1).extracting(StudentCourseDetail::getStudentCourse).contains(course1, course2);
-    assertThat(studentCourseDetailList1).extracting(StudentCourseDetail::getCourseApplicationStatus).contains(status1,status2);
+    assertThat(studentCourseDetailList1).extracting(StudentCourseDetail::getStudentCourse).contains(
+        course1, course2);
+    assertThat(studentCourseDetailList1).extracting(StudentCourseDetail::getCourseApplicationStatus).contains(
+        status1, status2);
 
     // 2人目の受講生詳細の中身を検証
     assertThat(actual.get(1).getStudent()).isEqualTo(student2);
     List<StudentCourseDetail> studentCourseDetailList2 = actual.get(1).getStudentCourseDetailList();
-    assertThat(studentCourseDetailList2).extracting(StudentCourseDetail::getStudentCourse).contains(course3);
-    assertThat(studentCourseDetailList2).extracting(StudentCourseDetail::getCourseApplicationStatus).contains(status3);
+    assertThat(studentCourseDetailList2).extracting(StudentCourseDetail::getStudentCourse).contains(
+        course3);
+    assertThat(studentCourseDetailList2).extracting(StudentCourseDetail::getCourseApplicationStatus).contains(
+        status3);
   }
 }

--- a/src/test/java/raisetech/StudentManagement/repository/StudentRepositoryTest.java
+++ b/src/test/java/raisetech/StudentManagement/repository/StudentRepositoryTest.java
@@ -10,6 +10,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import raisetech.studentmanagement.data.CourseApplicationStatus;
 import raisetech.studentmanagement.data.Student;
 import raisetech.studentmanagement.data.StudentCourse;
+import raisetech.studentmanagement.domain.StudentDetail;
+import raisetech.studentmanagement.domain.StudentSearchCriteria;
 
 @MybatisTest
 class StudentRepositoryTest {
@@ -98,6 +100,30 @@ class StudentRepositoryTest {
     CourseApplicationStatus actual = sut.findCourseApplicationStatusByCourseId(id);
 
     assertThat(actual.getStatus()).isEqualTo("本申込");
+  }
+
+  @Test
+  void 条件を指定した検索で何も指定しなかったとき全件を取得できること() {
+    StudentSearchCriteria criteria = new StudentSearchCriteria();
+
+    List<StudentDetail> actual = sut.searchStudentDetail(criteria);
+
+    assertThat(actual.size()).isEqualTo(6);
+    assertThat(actual).extracting("student.fullName")
+        .containsExactlyInAnyOrder("桐ヶ谷和人", "桐ヶ谷和人", "結城明日奈", "綾野珪子", "篠崎里香",
+            "壺井遼太郎");
+  }
+
+  @Test
+  void 条件を指定して検索したときに正しいデータが取得できること() {
+    StudentSearchCriteria criteria = new StudentSearchCriteria();
+    criteria.setGender("女性");
+
+    List<StudentDetail> actual = sut.searchStudentDetail(criteria);
+
+    assertThat(actual.size()).isEqualTo(3);
+    assertThat(actual).extracting("student.fullName")
+        .containsExactlyInAnyOrder("結城明日奈", "綾野珪子", "篠崎里香");
   }
 
   @Test

--- a/src/test/java/raisetech/StudentManagement/repository/StudentRepositoryTest.java
+++ b/src/test/java/raisetech/StudentManagement/repository/StudentRepositoryTest.java
@@ -21,11 +21,11 @@ class StudentRepositoryTest {
 
   /*
     初期のstudentsテーブル
-    ('桐ヶ谷和人', 'キリガヤカズト', 'キリト', 'kirito@sao.com', '埼玉', 17, '男性'),
-    ('結城明日奈', 'ユウキアスナ', 'アスナ', 'asuna@sao.com', '東京', 18, '女性'),
-    ('綾野珪子', 'アヤノケイコ', 'シリカ', 'silica@sao.com', '神奈川', 15, '女性'),
-    ('篠崎里香', 'シノザキリカ', 'リズベット', 'lisbeth@sao.com', '東京', 18, '女性'),
-    ('壺井遼太郎', 'ツボイリョウタロウ', 'クライン', 'klein@sao.com', '千葉', 27, '男性');
+    ('桐ヶ谷和人', 'キリガヤカズト', 'キリト', 'kirito@sao.com', '埼玉', 17, '男性', 'テスト'),
+    ('結城明日奈', 'ユウキアスナ', 'アスナ', 'asuna@sao.com', '東京', 18, '女性', 'test'),
+    ('綾野珪子', 'アヤノケイコ', 'シリカ', 'silica@sao.com', '神奈川', 15, '女性', 'てすと'),
+    ('篠崎里香', 'シノザキリカ', 'リズベット', 'lisbeth@sao.com', '東京', 18, '女性', 'テスト'),
+    ('壺井遼太郎', 'ツボイリョウタロウ', 'クライン', 'klein@sao.com', '千葉', 27, '男性', 'test')
    */
 
   /*
@@ -115,7 +115,79 @@ class StudentRepositoryTest {
   }
 
   @Test
-  void 条件を指定して検索したときに正しいデータが取得できること() {
+  void 名前を指定して検索したときに正しいデータが取得できること() {
+    StudentSearchCriteria criteria = new StudentSearchCriteria();
+    criteria.setFullName("桐ヶ谷");
+
+    List<StudentDetail> actual = sut.searchStudentDetail(criteria);
+
+    assertThat(actual.size()).isEqualTo(2);
+    assertThat(actual).extracting("student.fullName")
+        .containsExactlyInAnyOrder("桐ヶ谷和人", "桐ヶ谷和人");
+  }
+
+  @Test
+  void フリガナを指定して検索したときに正しいデータが取得できること() {
+    StudentSearchCriteria criteria = new StudentSearchCriteria();
+    criteria.setFurigana("キリガヤ");
+
+    List<StudentDetail> actual = sut.searchStudentDetail(criteria);
+
+    assertThat(actual.size()).isEqualTo(2);
+    assertThat(actual).extracting("student.fullName")
+        .containsExactlyInAnyOrder("桐ヶ谷和人", "桐ヶ谷和人");
+  }
+
+  @Test
+  void ニックネームを指定して検索したときに正しいデータが取得できること() {
+    StudentSearchCriteria criteria = new StudentSearchCriteria();
+    criteria.setNickname("キリト");
+
+    List<StudentDetail> actual = sut.searchStudentDetail(criteria);
+
+    assertThat(actual.size()).isEqualTo(2);
+    assertThat(actual).extracting("student.fullName")
+        .containsExactlyInAnyOrder("桐ヶ谷和人", "桐ヶ谷和人");
+  }
+
+  @Test
+  void メールアドレスを指定して検索したときに正しいデータが取得できること() {
+    StudentSearchCriteria criteria = new StudentSearchCriteria();
+    criteria.setEmailAddress("kirito");
+
+    List<StudentDetail> actual = sut.searchStudentDetail(criteria);
+
+    assertThat(actual.size()).isEqualTo(2);
+    assertThat(actual).extracting("student.fullName")
+        .containsExactlyInAnyOrder("桐ヶ谷和人", "桐ヶ谷和人");
+  }
+
+  @Test
+  void 地域を指定して検索したときに正しいデータが取得できること() {
+    StudentSearchCriteria criteria = new StudentSearchCriteria();
+    criteria.setArea("東京");
+
+    List<StudentDetail> actual = sut.searchStudentDetail(criteria);
+
+    assertThat(actual.size()).isEqualTo(2);
+    assertThat(actual).extracting("student.fullName")
+        .containsExactlyInAnyOrder("結城明日奈", "篠崎里香");
+  }
+
+  @Test
+  void 年齢を指定して検索したときに正しいデータが取得できること() {
+    StudentSearchCriteria criteria = new StudentSearchCriteria();
+    criteria.setAge(18);
+
+    List<StudentDetail> actual = sut.searchStudentDetail(criteria);
+
+    assertThat(actual.size()).isEqualTo(2);
+    assertThat(actual).extracting("student.fullName")
+        .containsExactlyInAnyOrder("結城明日奈", "篠崎里香");
+  }
+
+  @Test
+  void 性別を指定して検索したときに正しいデータが取得できること() {
     StudentSearchCriteria criteria = new StudentSearchCriteria();
     criteria.setGender("女性");
 
@@ -124,6 +196,66 @@ class StudentRepositoryTest {
     assertThat(actual.size()).isEqualTo(3);
     assertThat(actual).extracting("student.fullName")
         .containsExactlyInAnyOrder("結城明日奈", "綾野珪子", "篠崎里香");
+  }
+
+  @Test
+  void 備考を指定して検索したときに正しいデータが取得できること() {
+    StudentSearchCriteria criteria = new StudentSearchCriteria();
+    criteria.setRemark("test");
+
+    List<StudentDetail> actual = sut.searchStudentDetail(criteria);
+
+    assertThat(actual.size()).isEqualTo(2);
+    assertThat(actual).extracting("student.fullName")
+        .containsExactlyInAnyOrder("結城明日奈", "壺井遼太郎");
+  }
+
+  @Test
+  void コース名を指定して検索したときに正しいデータが取得できること() {
+    StudentSearchCriteria criteria = new StudentSearchCriteria();
+    criteria.setCourseName("java");
+
+    List<StudentDetail> actual = sut.searchStudentDetail(criteria);
+
+    assertThat(actual.size()).isEqualTo(2);
+    assertThat(actual).extracting("student.fullName")
+        .containsExactlyInAnyOrder("桐ヶ谷和人", "綾野珪子");
+  }
+
+  @Test
+  void 開始日を指定して検索したときに正しいデータが取得できること() {
+    StudentSearchCriteria criteria = new StudentSearchCriteria();
+    criteria.setStartDate(LocalDateTime.parse("2024-10-07T00:00:00")); // 設定した日付以降のデータが取得される
+
+    List<StudentDetail> actual = sut.searchStudentDetail(criteria);
+
+    assertThat(actual.size()).isEqualTo(3);
+    assertThat(actual).extracting("student.fullName")
+        .containsExactlyInAnyOrder("桐ヶ谷和人", "桐ヶ谷和人", "壺井遼太郎");
+  }
+
+  @Test
+  void 修了日を指定して検索したときに正しいデータが取得できること() {
+    StudentSearchCriteria criteria = new StudentSearchCriteria();
+    criteria.setEndDate(LocalDateTime.parse("2025-10-07T00:00:00")); // 設定した日付以前のデータが取得される
+
+    List<StudentDetail> actual = sut.searchStudentDetail(criteria);
+
+    assertThat(actual.size()).isEqualTo(4);
+    assertThat(actual).extracting("student.fullName")
+        .containsExactlyInAnyOrder("桐ヶ谷和人", "結城明日奈", "綾野珪子", "篠崎里香");
+  }
+
+  @Test
+  void 申し込み状況を指定して検索したときに正しいデータが取得できること() {
+    StudentSearchCriteria criteria = new StudentSearchCriteria();
+    criteria.setStatus("受講中");
+
+    List<StudentDetail> actual = sut.searchStudentDetail(criteria);
+
+    assertThat(actual.size()).isEqualTo(2);
+    assertThat(actual).extracting("student.fullName")
+        .containsExactlyInAnyOrder("結城明日奈", "綾野珪子");
   }
 
   @Test

--- a/src/test/java/raisetech/StudentManagement/service/StudentServiceTest.java
+++ b/src/test/java/raisetech/StudentManagement/service/StudentServiceTest.java
@@ -21,6 +21,7 @@ import raisetech.studentmanagement.data.Student;
 import raisetech.studentmanagement.data.StudentCourse;
 import raisetech.studentmanagement.domain.StudentCourseDetail;
 import raisetech.studentmanagement.domain.StudentDetail;
+import raisetech.studentmanagement.domain.StudentSearchCriteria;
 import raisetech.studentmanagement.repository.StudentRepository;
 
 @ExtendWith(MockitoExtension.class)
@@ -90,6 +91,19 @@ class StudentServiceTest {
         actual.getStudentCourseDetailList().getFirst().getCourseApplicationStatus().getId())
         .isEqualTo(
             expected.getStudentCourseDetailList().getFirst().getCourseApplicationStatus().getId());
+  }
+
+  @Test
+  void 条件を指定した受講生詳細の検索でリポジトリとコンバータの処理が適切に呼び出せていること() {
+    StudentSearchCriteria criteria = new StudentSearchCriteria();
+    List<StudentDetail> studentDetailList = new ArrayList<>();
+
+    when(repository.searchStudentDetail(criteria)).thenReturn(studentDetailList);
+
+   sut.searchStudentDetail(criteria);
+
+    verify(repository, times(1)).searchStudentDetail(criteria);
+    verify(converter, times(1)).convertSearchedStudentDetailList(studentDetailList);
   }
 
   @Test

--- a/src/test/resources/data.sql
+++ b/src/test/resources/data.sql
@@ -1,14 +1,14 @@
-INSERT INTO students (full_name, furigana, nickname, email_address, area, age, gender)
+INSERT INTO students (full_name, furigana, nickname, email_address, area, age, gender, remark)
 VALUES
-('桐ヶ谷和人', 'キリガヤカズト', 'キリト', 'kirito@sao.com', '埼玉', 17, '男性'),
-('結城明日奈', 'ユウキアスナ', 'アスナ', 'asuna@sao.com', '東京', 18, '女性'),
-('綾野珪子', 'アヤノケイコ', 'シリカ', 'silica@sao.com', '神奈川', 15, '女性'),
-('篠崎里香', 'シノザキリカ', 'リズベット', 'lisbeth@sao.com', '東京', 18, '女性'),
-('壺井遼太郎', 'ツボイリョウタロウ', 'クライン', 'klein@sao.com', '千葉', 27, '男性');
+('桐ヶ谷和人', 'キリガヤカズト', 'キリト', 'kirito@sao.com', '埼玉', 17, '男性', 'テスト'),
+('結城明日奈', 'ユウキアスナ', 'アスナ', 'asuna@sao.com', '東京', 18, '女性', 'test'),
+('綾野珪子', 'アヤノケイコ', 'シリカ', 'silica@sao.com', '神奈川', 15, '女性', 'てすと'),
+('篠崎里香', 'シノザキリカ', 'リズベット', 'lisbeth@sao.com', '東京', 18, '女性', 'テスト'),
+('壺井遼太郎', 'ツボイリョウタロウ', 'クライン', 'klein@sao.com', '千葉', 27, '男性', 'test');
 
 INSERT INTO students_courses (student_id, course_name, start_date, end_date)
 VALUES
-(1, 'java', ' 2024-10-07 00:00:00', '2025-10-07 00:00:00'),
+(1, 'java', '2024-10-07 00:00:00', '2025-10-07 00:00:00'),
 (1, 'aws', '2024-11-07 00:00:00', '2025-11-07 00:00:00'),
 (2, 'デザイン', '2024-09-30 00:00:00', '2025-09-30 00:00:00'),
 (3, 'java', '2024-10-04 00:00:00', '2025-10-04 00:00:00'),

--- a/src/test/resources/schema.sql
+++ b/src/test/resources/schema.sql
@@ -9,7 +9,7 @@ CREATE TABLE IF NOT EXISTS students
   age INT NOT NULL,
   gender VARCHAR(10),
   remark VARCHAR(100),
-  is_deleted boolean
+  is_deleted boolean DEFAULT FALSE
 );
 
 CREATE TABLE IF NOT EXISTS students_courses


### PR DESCRIPTION
絞り込み検索機能の実装
・id系、is_deletedカラムを除く条件で検索可能（文字列は部分一致検索可）
　┗検索はPOSTでJson形式のリクエストボディを渡す
　　→GETに修正
・条件が指定されていない場合は全件を返す
・is_deletedがfalseのデータのみ取得してくる
　┗is_deletedも検索条件に含めた方がよい？
　┗そうすれば全件検索のみのメソッドを消してもいいかも
・Repositoryでは生データを取得するため、複数コースを受講している受講生は重複する
　→Converterで重複したデータをまとめる処理を行い、Serviceで呼び出す
・検索条件に一致する受講生が見つからなかった場合は例外処理を行う